### PR TITLE
Use width and height directly if no aspect ratio is passed.

### DIFF
--- a/src/cropper.js
+++ b/src/cropper.js
@@ -296,7 +296,7 @@
         setData: function(data) {
             var cropper = this.cropper,
                 dragger = this.dragger,
-                aspectRatio = this.defaults.aspectRatio || 1;
+                aspectRatio = this.defaults.aspectRatio;
 
             if (!this.active) {
                 return;
@@ -313,18 +313,23 @@
                     dragger.top = data.y1;
                 }
 
-                if ($.isNumeric(data.width) && data.width > 0 && data.width <= cropper.width) {
+                if ( !isNaN(aspectRatio) ){
+                    if ($.isNumeric(data.width) && data.width > 0 && data.width <= cropper.width) {
+                        dragger.width = data.width;
+                        dragger.height = dragger.width / aspectRatio;
+                    } else if ($.isNumeric(data.height) && data.height > 0 && data.height <= cropper.height) {
+                        dragger.height = data.height;
+                        dragger.width = dragger.height * aspectRatio;
+                    } else if ($.isNumeric(data.x2) && data.x2 > 0 && data.x2 <= cropper.width) {
+                        dragger.width = data.x2 - dragger.left;
+                        dragger.height = dragger.width / aspectRatio;
+                    } else if ($.isNumeric(data.y2) && data.y2 > 0 && data.y2 <= cropper.height) {
+                        dragger.height = data.y2 - dragger.top;
+                        dragger.width = dragger.height * aspectRatio;
+                    }
+                } else {
                     dragger.width = data.width;
-                    dragger.height = dragger.width / aspectRatio;
-                } else if ($.isNumeric(data.height) && data.height > 0 && data.height <= cropper.height) {
                     dragger.height = data.height;
-                    dragger.width = dragger.height * aspectRatio;
-                } else if ($.isNumeric(data.x2) && data.x2 > 0 && data.x2 <= cropper.width) {
-                    dragger.width = data.x2 - dragger.left;
-                    dragger.height = dragger.width / aspectRatio;
-                } else if ($.isNumeric(data.y2) && data.y2 > 0 && data.y2 <= cropper.height) {
-                    dragger.height = data.y2 - dragger.top;
-                    dragger.width = dragger.height * aspectRatio;
                 }
             } else {
                 dragger.left = cropper.width * 0.1;


### PR DESCRIPTION
Currently setData won't work as expected (and documented) as aspect ratio will always be used, e.g. calling setData with `{"x1":0,"y1":0,"width":1500,"height":100}` even with the aspectRatio option unset or set to 'auto' will cause the height to be recalculated, thus the crop zone will be larger than specified.

This patch fixes this by only recalculating if aspectRatio was given as an option. If no aspect ratio is set the width and height will be used as-is.
