### PR TITLE
On initial cropper load, respect the aspect ratio passed in from user

### DIFF
--- a/src/cropper.js
+++ b/src/cropper.js
@@ -336,6 +336,11 @@
                 dragger.top = cropper.height * 0.1;
                 dragger.height = cropper.height * 0.8;
                 dragger.width = cropper.width * 0.8;
+
+                //respect aspect ratio
+                var minDimension = dragger.height < dragger.width ? Math.abs(dragger.height) : Math.abs(dragger.width);
+                dragger.width = minDimension;
+                dragger.height = minDimension;
             }
 
             this.dragger = dragger;


### PR DESCRIPTION
In the existing code, the dragger loads with a ratio that matches the image instead of the cropping aspect ratio.
