### PR TITLE
fix bug: adding $clone into DOM in function render causes a flash

### DIFF
--- a/src/cropper.js
+++ b/src/cropper.js
@@ -83,7 +83,6 @@
             }
 
             this.$clone = $clone;
-            $image.after($clone);
         },
 
         unrender: function () {


### PR DESCRIPTION
In the function render() there is a but that adding $clone into the DOM tree in this function will cause a flash of the $clone image in the browser page. By using a button to enable and disable the cropper repeatedly and rapidly in a page, you can observe it clearly. In fact, the $clone element will definitely be added into the DOM tree later in the createCropper function. So I just remove that line to git rid of this bug.
