### PR TITLE
Enable dragging across image borders

### DIFF
--- a/src/cropper.js
+++ b/src/cropper.js
@@ -25,7 +25,7 @@
             return typeof n === "number";
         },
 
-        // Construstor
+        // Constructor
         Cropper = function (element, options) {
             this.$image = $(element);
             this.setDefaults(options);
@@ -40,7 +40,7 @@
         num = parseFloat;
 
     Cropper.prototype = {
-        construstor: Cropper,
+        constructor: Cropper,
 
         isDragging: false,
 


### PR DESCRIPTION
Currently the drag event is cancelled as soon as the user drags the crop area outside of the cropper container. I implemented a way to enable dragging across the image borders, so the event doesn't get cancelled.

Changes in detail:
- A new property `isDragging` which indicates if the user is currently dragging or not.
- Setting/checking that property in the `dragstart`, `dragmove` and `dragend` functions.
- `event.preventDefault()` will be executed every time in `dragmove`, not only when `touching` is true. This ensures that no text will be selected, when the user drags outside of the cropper container.
- Little typo fixing.

As described in #54 this needs some fixing, but hopefully is a solid base.
