### PR TITLE
Adding ability to configure the minimum width/height of image container

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,22 @@ The maximum height (px of original image) of the cropping zone.
 Use this option only when you are sure that the image has this maximum height.
 
 
+#### minContainerWidth
+
+- type: `Number`
+- default: 300
+
+The minimum width of the block element containing the image.
+
+
+#### minContainerHeight
+
+- type: `Number`
+- default: 150
+
+The minimum height of the block element containing the image.
+
+
 #### build
 
 - type: `Function`

--- a/src/cropper.js
+++ b/src/cropper.js
@@ -388,8 +388,8 @@
       var $container = this.$container;
 
       this.container = {
-        width: max($container.width(), 300),
-        height: max($container.height(), 150)
+        width: max($container.width(), this.defaults.minContainerWidth),
+        height: max($container.height(), this.defaults.minContainerHeight)
       };
     },
 
@@ -1531,6 +1531,8 @@
     minHeight: 0,
     maxWidth: INFINITY,
     maxHeight: INFINITY,
+    minContainerWidth: 300,
+    minContainerHeight: 150,
 
     // Events
     build: NULL,


### PR DESCRIPTION
I've been working on a little app that uses cropper multiple times on small thumbnails on a page (250 x 375) and so I needed to be able to change these values. I'm not sure if this is the way you'd go about it, but at the moment you can't use cropper successfully on anything smaller than 300px height or 150px width.