### PR TITLE
#170 - Reduced the jQuery dependency to not include 2.x from jQuery.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tests
 utils
 workspace
 CHANGELOG.md
+bower_components

--- a/bower.json
+++ b/bower.json
@@ -32,6 +32,6 @@
     "docs"
   ],
   "dependencies": {
-    "jquery": ">= 1.9.0"
+    "jquery": ">= 1.9.0 <2.0.0"
   }
 }


### PR DESCRIPTION
#170 - Reducing the dependency to not include jQuery 2.x. This version of jQuery removes IE6,7,8 support and this library supports IE8. It will take the tip of 1.x without going into 2.x