### PR TITLE
Fixed an issue where 'crossorigin' attribute hasn't been removed

### DIFF
--- a/src/cropper.js
+++ b/src/cropper.js
@@ -664,6 +664,11 @@
 
         if ($this.is("img")) {
           $this.attr("src", url);
+          // Add/remove crossorigin attribute on the orignal element, based on the url
+          if (this.isCrossOriginURL(url))
+            $this.attr("crossorigin", true);
+          else
+            $this.removeAttr("crossOrigin");
           this.load();
         } else if ($this.is("canvas") && this.support.canvas) {
           context = element.getContext("2d");

--- a/src/cropper.js
+++ b/src/cropper.js
@@ -397,7 +397,15 @@
           image = this.image,
           cropper;
 
-      if (((image.naturalWidth * container.height / image.naturalHeight) - container.width) >= 0) {
+       if (this.defaults.useNaturalSize){
+        cropper = {
+          width: image.naturalWidth,
+          height: image.naturalHeight,
+          top: 0,
+        };
+
+        cropper.left = (container.width - cropper.width) / 2;
+      } else if (((image.naturalWidth * container.height / image.naturalHeight) - container.width) >= 0) {
         cropper = {
           width: container.width,
           height: container.width / image.aspectRatio,
@@ -1558,6 +1566,7 @@
     zoomable: TRUE,
     rotatable: TRUE,
     checkImageOrigin: TRUE,
+    useNaturalSize: TRUE,
 
     // Dimensions
     minWidth: 0,


### PR DESCRIPTION
Fixed an issue where 'crossorigin' attribute hasn't been removed from the original element when the 'src' changes to base64. The change also adds the attribute if the url changes the a crossorigin url. Branch: master