### PR TITLE
Fixing #134 for Chrome: seems like the order matters

### DIFF
--- a/dist/cropper.js
+++ b/dist/cropper.js
@@ -248,8 +248,9 @@
     }, this)).one('error', function () {
       $clone.remove();
     }).attr({
-      src: bustCacheUrl || url,
-      crossOrigin: crossOrigin
+      /* #134: Seems like the order is important for Chrome. */
+      crossOrigin: crossOrigin,
+      src: bustCacheUrl || url
     });
 
     // Hide and insert into the document


### PR DESCRIPTION
Loading Cross-origin content is sensitive for Chrome and ‘crossOrigin’ attribute has to be set first.

Tested against Chrome 41, 42 on Mac.
Could be jQuery-specific issue - ‘src’ is fired before ‘crossOrigin’ has been applied