### PR TITLE
Add setData method to allow "loading" crop information back onto an image

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -198,6 +198,11 @@
           <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;getData&quot;)">
             Get Data
           </span>
+        </button>
+        <button class="btn btn-primary" data-method="setData" data-target="#putData" type="button">
+            <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;setData&quot;, data)">
+                Set Data
+            </span>
         </button>
         <button class="btn btn-primary" data-method="getImageData" data-option="" data-target="#putData" type="button">
           <span class="docs-tooltip" data-toggle="tooltip" title="$().cropper(&quot;getImageData&quot;)">

--- a/src/js/methods.js
+++ b/src/js/methods.js
@@ -155,6 +155,51 @@
       return data;
     },
 
+    setData: function (data) {
+      var cropBox = this.cropBox,
+          canvas = this.canvas,
+          image = this.image,
+          aspectRatio = this.options.aspectRatio,
+          ratio = image.width / image.naturalWidth;
+
+      if (this.built && !this.disabled && $.isPlainObject(data)) {
+        if (isNumber(data.x)) {
+          cropBox.left = data.x * ratio + canvas.left;
+        }
+
+        if (isNumber(data.y)) {
+          cropBox.top = data.y * ratio + canvas.top;
+        }
+
+        if (aspectRatio) {
+          if (isNumber(data.width)) {
+            cropBox.width = data.width * ratio;
+            cropBox.height = cropBox.width / aspectRatio;
+          } else if (isNumber(data.height)) {
+            cropBox.height = data.height * ratio;
+            cropBox.width = cropBox.height / aspectRatio;
+          }
+        }
+        else {
+          if (isNumber(data.width)) {
+            cropBox.width = data.width * ratio;
+          }
+
+          if (isNumber(data.height)) {
+            cropBox.height = data.height * ratio;
+          }
+        }
+
+        if (this.ready && isNumber(data.rotate) && this.built && !this.disabled && this.options.rotatable) {
+          this.rotated = true;
+          image.rotate = data.rotate;
+          this.renderCanvas(true);
+        }
+
+        this.renderCropBox();
+      }
+    },
+
     getContainerData: function () {
       return this.built ? this.container : {};
     },

--- a/test/methods.html
+++ b/test/methods.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
@@ -25,6 +25,7 @@
   <script src="methods/zoom.js"></script>
   <script src="methods/rotate.js"></script>
   <script src="methods/getData.js"></script>
+  <script src="methods/setData.js"></script>
   <script src="methods/getImageData.js"></script>
   <script src="methods/getCropBoxData.js"></script>
   <script src="methods/setCropBoxData.js"></script>

--- a/test/methods/setData.js
+++ b/test/methods/setData.js
@@ -1,0 +1,60 @@
+$(function () {
+
+  'use strict';
+
+  var $image = $(window.createCropperImage()),
+      isNumber = function (n) {
+        return typeof n === 'number' && !isNaN(n);
+      };
+
+  $image.cropper({
+    built: function () {
+      var _data = $image.cropper('getData');
+
+      QUnit.test('methods.setData', function (assert) {
+        var data = $image.cropper('setData', {
+              left: 16,
+              height: 120
+            }).cropper('getData');
+
+        assert.ok($.isPlainObject(data));
+        assert.ok(isNumber(data.left));
+        assert.ok(isNumber(data.top));
+        assert.ok(isNumber(data.width));
+        assert.ok(isNumber(data.height));
+
+        assert.notEqual(data.left, _data.left);
+        assert.equal(data.top, _data.top);
+        assert.equal(data.width, _data.width);
+        assert.notEqual(data.height, _data.height);
+      });
+
+      QUnit.test('methods.setData: move', function (assert) {
+        var data = $image.cropper('reset').cropper('setData', {
+              left: 16,
+              top: 9
+            }).cropper('getData');
+
+        assert.notEqual(data.left, _data.left);
+        assert.notEqual(data.top, _data.top);
+        assert.equal(data.width, _data.width);
+        assert.equal(data.height, _data.height);
+      });
+
+
+      QUnit.test('methods.setData: resize', function (assert) {
+        var data = $image.cropper('reset').cropper('setData', {
+              width: 320,
+              height: 180
+            }).cropper('getData');
+
+        assert.equal(data.left, _data.left);
+        assert.equal(data.top, _data.top);
+        assert.notEqual(data.width, _data.width);
+        assert.notEqual(data.height, _data.height);
+      });
+
+    }
+  });
+
+});

--- a/test/methods/setData.js
+++ b/test/methods/setData.js
@@ -13,30 +13,30 @@ $(function () {
 
       QUnit.test('methods.setData', function (assert) {
         var data = $image.cropper('setData', {
-              left: 16,
+              x: 16,
               height: 120
             }).cropper('getData');
 
         assert.ok($.isPlainObject(data));
-        assert.ok(isNumber(data.left));
-        assert.ok(isNumber(data.top));
+        assert.ok(isNumber(data.x));
+        assert.ok(isNumber(data.y));
         assert.ok(isNumber(data.width));
         assert.ok(isNumber(data.height));
 
-        assert.notEqual(data.left, _data.left);
-        assert.equal(data.top, _data.top);
+        assert.notEqual(data.x, _data.x);
+        assert.equal(data.y, _data.y);
         assert.equal(data.width, _data.width);
         assert.notEqual(data.height, _data.height);
       });
 
       QUnit.test('methods.setData: move', function (assert) {
         var data = $image.cropper('reset').cropper('setData', {
-              left: 16,
-              top: 9
+              x: 16,
+              y: 9
             }).cropper('getData');
 
-        assert.notEqual(data.left, _data.left);
-        assert.notEqual(data.top, _data.top);
+        assert.notEqual(data.x, _data.x);
+        assert.notEqual(data.y, _data.y);
         assert.equal(data.width, _data.width);
         assert.equal(data.height, _data.height);
       });
@@ -48,8 +48,8 @@ $(function () {
               height: 180
             }).cropper('getData');
 
-        assert.equal(data.left, _data.left);
-        assert.equal(data.top, _data.top);
+        assert.equal(data.x, _data.x);
+        assert.equal(data.y, _data.y);
         assert.notEqual(data.width, _data.width);
         assert.notEqual(data.height, _data.height);
       });


### PR DESCRIPTION
This is needed in a system that crops on the fly, and allows users to return and edit crops later. All other getXXX methods return data has has been scaled in some way, so if you only store actual pixel sizes for the crop information, this is required to restore the crop without doing lots of maths.

I see that this existed in a previous version but was removed. It's not clear why, but I'm hoping you'll consider merging it back in to avoid us maintaining a separate fork. I have added tests, and a button to the sample page.

(I also manually tested rotation as that didn't seem to exist on the sample page)

This PR will fix Issue #290.