### PR TITLE
Make zoom method consistent between positive and negative values

### DIFF
--- a/src/js/methods.js
+++ b/src/js/methods.js
@@ -124,7 +124,7 @@
           return;
         }
 
-        delta = delta <= -1 ? 1 / (1 - delta) : delta <= 1 ? (1 + delta) : delta;
+        delta = delta < -1 ? 1 / (-delta) : delta <= 0 ? 1 / (1 - delta) : delta <= 1 ? (1 + delta) : delta;
         width = canvas.width * delta;
         height = canvas.height * delta;
         canvas.left -= (width - canvas.width) / 2;


### PR DESCRIPTION
Previously, giving the zoom function a value of 0.9 would cause a 1.9X zoom, but giving it a value of -0.9 would cause a 10X zoom out. Moreover, a value of -2 would cause a 3X zoom out, while a value of 2 would cause a 2X zoom in. Now, a value of -0.9 will give a zoom out of 1.9X and a value of -2 will give a zoom out 2X.