### PR TITLE
Zoom coefficient option

### DIFF
--- a/dist/cropper.js
+++ b/dist/cropper.js
@@ -972,7 +972,7 @@
         delta = e.detail > 0 ? 1 : -1;
       }
 
-      this.zoom(-delta * 0.1);
+      this.zoom(-delta * this.options.zoomRatio);
     },
 
     dragstart: function (event) {
@@ -1561,6 +1561,26 @@
       }
     },
 
+    setZoomRatio: function (zoomRatio) {
+      var options = this.options;
+
+      if (!this.disabled && !isUndefined(zoomRatio)) {
+        options.zoomRatio = num(zoomRatio) || NaN; // 0 -> NaN
+
+        if (this.built) {
+          this.initCropBox();
+
+          if (this.cropped) {
+            this.renderCropBox();
+          }
+        }
+      }
+	},
+
+    getZoomRatio: function () {
+      return this.options.zoomRatio;
+	},
+
     setDragMode: function (mode) {
       var options = this.options,
           croppable,
@@ -1983,6 +2003,7 @@
     // Defines the aspect ratio of the crop box
     // Type: Number
     aspectRatio: NaN,
+    zoomRatio: 0.1,
 
     // Defines the percentage of automatic cropping area when initializes
     // Type: Number (Must large than 0 and less than 1)

--- a/dist/cropper.js
+++ b/dist/cropper.js
@@ -1564,22 +1564,14 @@
     setZoomRatio: function (zoomRatio) {
       var options = this.options;
 
-      if (!this.disabled && !isUndefined(zoomRatio)) {
-        options.zoomRatio = num(zoomRatio) || NaN; // 0 -> NaN
-
-        if (this.built) {
-          this.initCropBox();
-
-          if (this.cropped) {
-            this.renderCropBox();
-          }
-        }
+      if (!isUndefined(zoomRatio)) {
+        options.zoomRatio = num(zoomRatio) || 0.1;
       }
-	},
+    },
 
     getZoomRatio: function () {
       return this.options.zoomRatio;
-	},
+    },
 
     setDragMode: function (mode) {
       var options = this.options,


### PR DESCRIPTION
With _$().cropper('zoom', num)_ the user can choose the zoom ratio that want, but when scrolling the zoom ratio is 0.1.

Required in [#251](https://github.com/fengyuanchen/cropper/issues/251)

##### I added:
- a option _zoomRatio_ to specific the zoom ratio (default is 0.1);
- a method to set _zoomRatio_ and another to get it (_setZoomRatio_ and _getZoomRatio_);

##### examples
`$().cropper({`
`    zoomRatio: 0.03 //default is 0.1`
`});`

`$().cropper('setZoomRatio', 0.15);`
`$().cropper('getZoomRatio'); //return zoomRatio value`

`$().cropper('zoom', +1 * $().cropper('getZoomRatio')); //zoom in`
`$().cropper('zoom', -1 * $().cropper('getZoomRatio')); //zoom out`