### PR TITLE
Add reinitialize method

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,11 @@ Disable (freeze) the cropper.
 Destroy the cropper and remove the instance from the image.
 
 
+### reinitialize()
+
+Reinitialize the cropper with exactly same data than before.
+
+
 ### move(offsetX[, offsetY])
 
 - **offsetX**:

--- a/src/js/methods.js
+++ b/src/js/methods.js
@@ -115,6 +115,12 @@
       $this.removeData(NAMESPACE);
     },
 
+    // Destroy the cropper and remove the instance from the image and then initialize it again
+    reinitialize: function () {
+      this.destroy();
+      this.init();
+    },
+
     /**
      * Move the canvas
      *


### PR DESCRIPTION
Add shortcut for method described in https://github.com/fengyuanchen/cropper/issues/421

With that patch we no longer need to pass settings the second time when nothing has changed (except device orientation).

As we're basically calling already tested (internal) methods I've skipped tests.