### PR TITLE
Improved preview crossOrigin for Chrome Super-cache

### DIFF
--- a/src/js/preview.js
+++ b/src/js/preview.js
@@ -1,10 +1,15 @@
   $.extend(prototype, {
     initPreview: function () {
+      var bustCacheUrl;
       var crossOrigin = getCrossOrigin(this.crossOrigin);
       var url = this.url;
 
+      if (this.options.checkCrossOrigin && isCrossOriginURL(url)) {
+        bustCacheUrl = addTimestamp(url);
+      }
+
       this.$preview = $(this.options.preview);
-      this.$viewBox.html('<img' + crossOrigin + ' src="' + url + '">');
+      this.$viewBox.html('<img' + crossOrigin + ' src="' + (bustCacheUrl || url) + '">');
       this.$preview.each(function () {
         var $this = $(this);
 


### PR DESCRIPTION
An error has occurred only in chrome when getting the cross-origin image in the preview area.