### PR TITLE
Fix initial load of rotated image

### DIFF
--- a/src/js/render.js
+++ b/src/js/render.js
@@ -35,9 +35,10 @@
       var containerWidth = container.width;
       var containerHeight = container.height;
       var image = this.image;
+      var image.rotate = this.image.rotate || this.options.rotate;
       var imageNaturalWidth = image.naturalWidth;
       var imageNaturalHeight = image.naturalHeight;
-      var is90Degree = abs(image.rotate) === 90;
+      var is90Degree = (image.rotate % 360) === 90 || (image.rotate % 360) === 270;
       var naturalWidth = is90Degree ? imageNaturalHeight : imageNaturalWidth;
       var naturalHeight = is90Degree ? imageNaturalWidth : imageNaturalHeight;
       var aspectRatio = naturalWidth / naturalHeight;

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -35,7 +35,7 @@
       var containerWidth = container.width;
       var containerHeight = container.height;
       var image = this.image;
-      var image.rotate = this.image.rotate || this.options.rotate;
+      image.rotate = this.image.rotate || this.options.rotate;
       var imageNaturalWidth = image.naturalWidth;
       var imageNaturalHeight = image.naturalHeight;
       var is90Degree = (image.rotate % 360) === 90 || (image.rotate % 360) === 270;

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -38,7 +38,7 @@
       image.rotate = this.image.rotate || this.options.rotate;
       var imageNaturalWidth = image.naturalWidth;
       var imageNaturalHeight = image.naturalHeight;
-      var is90Degree = (image.rotate % 360) === 90 || (image.rotate % 360) === 270;
+      var is90Degree = abs(image.rotate % 360) === 90 || abs(image.rotate % 360) === 270;
       var naturalWidth = is90Degree ? imageNaturalHeight : imageNaturalWidth;
       var naturalHeight = is90Degree ? imageNaturalWidth : imageNaturalHeight;
       var aspectRatio = naturalWidth / naturalHeight;


### PR DESCRIPTION
When user have crop data which includes rotate degree and user try to create new Cropper with that data the image does not show up fully. This happens when rotate degree is 90 or 270. In initCanvas "this.image.rotate" will always be undefined on the first load. Code change: use rotate from image or use it from options that user passed in and update aspectRatio correctly.