### PR TITLE
Allow dynamically to edit minCropBox Width/Height

### DIFF
--- a/src/js/methods.js
+++ b/src/js/methods.js
@@ -637,6 +637,16 @@ export default {
         cropBox.height = data.height;
       }
 
+      if (utils.isNumber(data.minCropBoxHeight)) {
+					cropBox.minHeight = data.minCropBoxHeight;
+					self.options.minCropBoxHeight = data.minCropBoxHeight;
+				}
+
+				if (utils.isNumber(data.minCropBoxWidth)) {
+					cropBox.minWidth = data.minCropBoxWidth;
+					self.options.minCropBoxWidth = data.minCropBoxWidth;
+				}
+
       if (aspectRatio) {
         if (widthChanged) {
           cropBox.height = cropBox.width / aspectRatio;
@@ -645,6 +655,7 @@ export default {
         }
       }
 
+      self.options.cropBox = cropBox;
       self.renderCropBox();
     }
   },


### PR DESCRIPTION
With these changes the setCropBoxData allow users to set the minCropBoxWidth and minCropBoxHeight dynamically after the cropper has been initialized. The method should be called as usual:

`$().cropper('setCropBoxData', dataObj)`

where the dataObj contains the data for the cropBox.